### PR TITLE
add `.forecasts` property that retrieves forecasts

### DIFF
--- a/stormevents/nhc/track.py
+++ b/stormevents/nhc/track.py
@@ -923,7 +923,7 @@ class VortexTrack:
         return wind_swaths
 
     @property
-    def forecasts(self) -> Dict[str, Dict[datetime, DataFrame]]:
+    def forecasts(self) -> Dict[str, List[DataFrame]]:
         data = self.data
 
         forecast_advisories = (
@@ -936,10 +936,10 @@ class VortexTrack:
 
             initial_times = pandas.unique(advisory_data['datetime'])
 
-            forecasts[advisory] = {}
+            forecasts[advisory] = []
             for initial_time in initial_times:
                 forecast_data = advisory_data[advisory_data['datetime'] == initial_time]
-                forecasts[advisory][initial_time] = forecast_data.sort_values('forecast_hours')
+                forecasts[advisory].append(forecast_data.sort_values('forecast_hours'))
 
         return forecasts
 

--- a/stormevents/nhc/track.py
+++ b/stormevents/nhc/track.py
@@ -923,6 +923,27 @@ class VortexTrack:
         return wind_swaths
 
     @property
+    def forecasts(self) -> Dict[str, Dict[datetime, DataFrame]]:
+        data = self.data
+
+        forecast_advisories = (
+            advisory for advisory in pandas.unique(data['advisory']) if advisory != 'BEST'
+        )
+
+        forecasts = {}
+        for advisory in forecast_advisories:
+            advisory_data = data[data['advisory'] == advisory]
+
+            initial_times = pandas.unique(advisory_data['datetime'])
+
+            forecasts[advisory] = {}
+            for initial_time in initial_times:
+                forecast_data = advisory_data[advisory_data['datetime'] == initial_time]
+                forecasts[advisory][initial_time] = forecast_data.sort_values('forecast_hours')
+
+        return forecasts
+
+    @property
     def duration(self) -> pandas.Timedelta:
         """
         :return: duration of current track

--- a/stormevents/nhc/track.py
+++ b/stormevents/nhc/track.py
@@ -923,7 +923,7 @@ class VortexTrack:
         return wind_swaths
 
     @property
-    def forecasts(self) -> Dict[str, List[DataFrame]]:
+    def forecasts(self) -> Dict[str, Dict[str, DataFrame]]:
         data = self.data
 
         forecast_advisories = (
@@ -936,10 +936,12 @@ class VortexTrack:
 
             initial_times = pandas.unique(advisory_data['datetime'])
 
-            forecasts[advisory] = []
+            forecasts[advisory] = {}
             for initial_time in initial_times:
                 forecast_data = advisory_data[advisory_data['datetime'] == initial_time]
-                forecasts[advisory].append(forecast_data.sort_values('forecast_hours'))
+                forecasts[advisory][
+                    f'{pandas.to_datetime(initial_time):%Y%m%dT%H%M%S}'
+                ] = forecast_data.sort_values('forecast_hours')
 
         return forecasts
 

--- a/tests/test_nhc.py
+++ b/tests/test_nhc.py
@@ -97,14 +97,14 @@ def test_vortex_track_properties():
     assert len(track) == 175
 
 
-def test_forecasts():
-    track = VortexTrack('florence2018', file_deck='a')
+def test_vortex_track_forecasts():
+    track = VortexTrack.from_storm_name('florence', 2018, file_deck='a')
 
     forecasts = track.forecasts
 
     assert len(forecasts) == 4
     assert len(forecasts['OFCL']) == 77
-    assert len(forecasts['OFCL'][0]) == 13
+    assert len(forecasts['OFCL']['20180830T120000']) == 13
 
 
 @pytest.mark.disable_socket

--- a/tests/test_nhc.py
+++ b/tests/test_nhc.py
@@ -97,6 +97,16 @@ def test_vortex_track_properties():
     assert len(track) == 175
 
 
+def test_forecasts():
+    track = VortexTrack('florence2018', file_deck='a')
+
+    forecasts = track.forecasts
+
+    assert len(forecasts) == 4
+    assert len(forecasts['OFCL']) == 77
+    assert len(forecasts['OFCL'][0]) == 13
+
+
 @pytest.mark.disable_socket
 def test_vortex_track_from_file():
     input_directory = INPUT_DIRECTORY / 'test_vortex_track_from_file'


### PR DESCRIPTION
as defined from https://github.com/oceanmodeling/StormEvents/pull/30#issuecomment-1083241363

copies implementation from https://tropycal.github.io/tropycal/_modules/tropycal/tracks/storm.html#Storm.get_operational_forecasts

closes #26