### PR TITLE
Fix the issue with data files not being copied to the installation directory 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,3 +37,6 @@ documentation =
     m2r2
     sphinx
     sphinx-rtd-theme
+
+[options.package_data]
+* = *.json

--- a/stormevents/nhc/storms.py
+++ b/stormevents/nhc/storms.py
@@ -192,6 +192,8 @@ def nhc_storms_gis_archive(year: int = None) -> pandas.DataFrame:
 
     url = 'http://www.nhc.noaa.gov/gis/archive_wsurge.php'
     response = requests.get(url, params={'year': year})
+    if not response.ok:
+        response.raise_for_status()
     soup = BeautifulSoup(response.content, features='html.parser')
     table = soup.find('table')
 


### PR DESCRIPTION
This issue shows up when testing getting COOPS stations using PyPI installed version of the package (**not** when using repo dev version).

While testing the fix, HTTP requests failed resulting in strange errors from user perspective. Added checks to raise better exceptions when HTTP requests fail when fetching data