### PR TITLE
Fix upload to github workflow env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,11 @@ jobs:
           name: package
           path: dist/
       - uses: xresloader/upload-to-github-release@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           file: "dist/*"
+          tags: true
   publish:
     name: publish package
     needs: [ build ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,12 +23,6 @@ jobs:
         with:
           name: package
           path: dist/
-      - uses: xresloader/upload-to-github-release@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          file: "dist/*"
-          tags: true
   publish:
     name: publish package
     needs: [ build ]


### PR DESCRIPTION
The `build` workflow seems to be missing some environment setup as described in https://github.com/xresloader/upload-to-github-release