### PR TITLE
Bug fix/get filedeck fromfile

### DIFF
--- a/stormevents/nhc/track.py
+++ b/stormevents/nhc/track.py
@@ -116,7 +116,7 @@ class VortexTrack:
         start_date: datetime = None,
         end_date: datetime = None,
         file_deck: ATCF_FileDeck = None,
-        advisories: [ATCF_Advisory] = None,
+        advisories: List[ATCF_Advisory] = None,
     ) -> "VortexTrack":
         """
         :param name: storm name
@@ -148,7 +148,7 @@ class VortexTrack:
         start_date: datetime = None,
         end_date: datetime = None,
         file_deck: ATCF_FileDeck = None,
-        advisories: [ATCF_Advisory] = None,
+        advisories: List[ATCF_Advisory] = None,
     ) -> "VortexTrack":
         """
         :param path: file path to ATCF data

--- a/stormevents/nhc/track.py
+++ b/stormevents/nhc/track.py
@@ -366,7 +366,7 @@ class VortexTrack:
 
     @file_deck.setter
     def file_deck(self, file_deck: ATCF_FileDeck):
-        if file_deck is None and self.filename is None:
+        if file_deck is None:
             if self.advisories is not None or len(self.advisories) > 0:
                 if ATCF_Advisory.BEST in typepigeon.convert_value(
                     self.advisories, [ATCF_Advisory]

--- a/stormevents/nhc/track.py
+++ b/stormevents/nhc/track.py
@@ -54,7 +54,7 @@ class VortexTrack:
         :param start_date: start date of track
         :param end_date: end date of track
         :param file_deck: ATCF file deck; one of `a`, `b`, `f`
-        :param advisories: ATCF advisory types; one of `BEST`, `OFCL`, `OFCP`, `HMON`, `CARQ`, `HWRF`
+        :param advisories: ATCF advisory type; one of ``BEST``, ``OFCL``, ``OFCP``, ``HMON``, ``CARQ``, ``HWRF``
 
         >>> VortexTrack('AL112017')
         VortexTrack('AL112017', Timestamp('2017-08-30 00:00:00'), Timestamp('2017-09-13 12:00:00'), <ATCF_FileDeck.BEST: 'b'>, <ATCF_Mode.HISTORICAL: 'ARCHIVE'>, [<ATCF_Advisory.BEST: 'BEST'>], None)
@@ -124,7 +124,7 @@ class VortexTrack:
         :param start_date: start date of track
         :param end_date: end date of track
         :param file_deck: ATCF file deck; one of ``a``, ``b``, ``f``
-        :param advisories: ATCF advisory type; one of ``BEST``, ``OFCL``, ``OFCP``, ``HMON``, ``CARQ``, ``HWRF``
+        :param advisories: list of ATCF advisory types; valid choices are: ``BEST``, ``OFCL``, ``OFCP``, ``HMON``, ``CARQ``, `HWRF``
 
         >>> VortexTrack.from_storm_name('irma', 2017)
         VortexTrack('AL112017', Timestamp('2017-08-30 00:00:00'), Timestamp('2017-09-13 12:00:00'), <ATCF_FileDeck.BEST: 'b'>, [<ATCF_Advisory.BEST: 'BEST'>], None)
@@ -155,7 +155,7 @@ class VortexTrack:
         :param start_date: start date of track
         :param end_date: end date of track
         :param file_deck: ATCF file deck; one of ``a``, ``b``, ``f``
-        :param advisories: ATCF advisory type; one of ``BEST``, ``OFCL``, ``OFCP``, ``HMON``, ``CARQ``, ``HWRF``
+        :param advisories: list of ATCF advisory types; valid choices are: ``BEST``, ``OFCL``, ``OFCP``, ``HMON``, ``CARQ``, `HWRF``
 
         >>> VortexTrack.from_file('tests/data/input/test_vortex_track_from_file/AL062018.dat')
         VortexTrack('AL062018', Timestamp('2018-08-30 06:00:00'), Timestamp('2018-09-18 12:00:00'), None, <ATCF_Mode.HISTORICAL: 'ARCHIVE'>, ['BEST', 'OFCL', 'OFCP', 'HMON', 'CARQ', 'HWRF'], PosixPath('/home/zrb/Projects/StormEvents/tests/data/input/test_vortex_track_from_file/AL062018.dat'))
@@ -164,8 +164,10 @@ class VortexTrack:
         """
 
         if file_deck is None and advisories is None:
-            warnings.warn('It is recommended to specify the file_deck and/or advisories when reading from file')
-        
+            warnings.warn(
+                "It is recommended to specify the file_deck and/or advisories when reading from file"
+            )
+
         try:
             path = pathlib.Path(path)
         except:

--- a/stormevents/nhc/track.py
+++ b/stormevents/nhc/track.py
@@ -3,6 +3,7 @@ import io
 import logging
 import pathlib
 import re
+import warnings
 from datetime import datetime
 from datetime import timedelta
 from functools import partial
@@ -162,12 +163,21 @@ class VortexTrack:
         VortexTrack('AL112017', Timestamp('2017-09-05 00:00:00'), Timestamp('2017-09-12 00:00:00'), None, <ATCF_Mode.HISTORICAL: 'ARCHIVE'>, ['BEST', 'OFCL', 'OFCP', 'HMON', 'CARQ', 'HWRF'], PosixPath('/home/zrb/Projects/StormEvents/tests/data/input/test_vortex_track_from_file/irma2017_fort.22'))
         """
 
+        if file_deck is None and advisories is None:
+            warnings.warn('It is recommended to specify the file_deck and/or advisories when reading from file')
+        
         try:
             path = pathlib.Path(path)
         except:
             pass
 
-        return cls(storm=path, start_date=start_date, end_date=end_date)
+        return cls(
+            storm=path,
+            start_date=start_date,
+            end_date=end_date,
+            file_deck=file_deck,
+            advisories=advisories,
+        )
 
     @property
     def name(self) -> str:
@@ -370,7 +380,7 @@ class VortexTrack:
 
     @file_deck.setter
     def file_deck(self, file_deck: ATCF_FileDeck):
-        if file_deck is None:
+        if file_deck is None and self.filename is None:
             if self.advisories is not None or len(self.advisories) > 0:
                 if ATCF_Advisory.BEST in typepigeon.convert_value(
                     self.advisories, [ATCF_Advisory]

--- a/stormevents/nhc/track.py
+++ b/stormevents/nhc/track.py
@@ -146,11 +146,15 @@ class VortexTrack:
         path: PathLike,
         start_date: datetime = None,
         end_date: datetime = None,
+        file_deck: ATCF_FileDeck = None,
+        advisories: [ATCF_Advisory] = None,
     ) -> "VortexTrack":
         """
         :param path: file path to ATCF data
         :param start_date: start date of track
         :param end_date: end date of track
+        :param file_deck: ATCF file deck; one of ``a``, ``b``, ``f``
+        :param advisories: ATCF advisory type; one of ``BEST``, ``OFCL``, ``OFCP``, ``HMON``, ``CARQ``, ``HWRF``
 
         >>> VortexTrack.from_file('tests/data/input/test_vortex_track_from_file/AL062018.dat')
         VortexTrack('AL062018', Timestamp('2018-08-30 06:00:00'), Timestamp('2018-09-18 12:00:00'), None, <ATCF_Mode.HISTORICAL: 'ARCHIVE'>, ['BEST', 'OFCL', 'OFCP', 'HMON', 'CARQ', 'HWRF'], PosixPath('/home/zrb/Projects/StormEvents/tests/data/input/test_vortex_track_from_file/AL062018.dat'))

--- a/tests/test_nhc.py
+++ b/tests/test_nhc.py
@@ -260,13 +260,13 @@ def test_vortex_track_no_internet():
     track_1 = VortexTrack.from_file(input_directory / "fort.22", file_deck='b')
     track_1.to_file(output_directory / "vortex_1.22", overwrite=True)
 
-    track_2 = VortexTrack.from_file(track_1.filename, file_deck='b')
+    track_2 = VortexTrack.from_file(track_1.filename)
     track_2.to_file(output_directory / "vortex_2.22", overwrite=True)
 
     track_3 = copy(track_1)
     track_3.to_file(output_directory / "vortex_3.22", overwrite=True)
 
-    assert track_1 == track_2
+    assert track_1 != track_2 # because file_deck is not specifided for track_2
     assert track_1 == track_3
 
     check_reference_directory(output_directory, reference_directory)

--- a/tests/test_nhc.py
+++ b/tests/test_nhc.py
@@ -267,9 +267,7 @@ def test_vortex_track_no_internet():
     track_3.to_file(output_directory / "vortex_3.22", overwrite=True)
 
     assert track_1 == track_2
-    assert (
-        track_1 != track_3
-    )  # these are not the same because of the velocity recalculation
+    assert track_1 == track_3
 
     check_reference_directory(output_directory, reference_directory)
 

--- a/tests/test_nhc.py
+++ b/tests/test_nhc.py
@@ -257,10 +257,11 @@ def test_vortex_track_no_internet():
     with pytest.raises((ConnectionError, SocketBlockedError)):
         VortexTrack(storm="al062018", start_date="20180911", end_date=None)
 
-    track_1 = VortexTrack.from_file(input_directory / "fort.22")
+    breakpoint()
+    track_1 = VortexTrack.from_file(input_directory / "fort.22", file_deck='b')
     track_1.to_file(output_directory / "vortex_1.22", overwrite=True)
 
-    track_2 = VortexTrack.from_file(track_1.filename)
+    track_2 = VortexTrack.from_file(track_1.filename, file_deck='b')
     track_2.to_file(output_directory / "vortex_2.22", overwrite=True)
 
     track_3 = copy(track_1)

--- a/tests/test_nhc.py
+++ b/tests/test_nhc.py
@@ -257,7 +257,7 @@ def test_vortex_track_no_internet():
     with pytest.raises((ConnectionError, SocketBlockedError)):
         VortexTrack(storm="al062018", start_date="20180911", end_date=None)
 
-    track_1 = VortexTrack.from_file(input_directory / "fort.22", file_deck='b')
+    track_1 = VortexTrack.from_file(input_directory / "fort.22", file_deck="b")
     track_1.to_file(output_directory / "vortex_1.22", overwrite=True)
 
     track_2 = VortexTrack.from_file(track_1.filename)
@@ -266,7 +266,7 @@ def test_vortex_track_no_internet():
     track_3 = copy(track_1)
     track_3.to_file(output_directory / "vortex_3.22", overwrite=True)
 
-    assert track_1 != track_2 # because file_deck is not specifided for track_2
+    assert track_1 != track_2  # because file_deck is not specified for track_2
     assert track_1 == track_3
 
     check_reference_directory(output_directory, reference_directory)

--- a/tests/test_nhc.py
+++ b/tests/test_nhc.py
@@ -257,7 +257,6 @@ def test_vortex_track_no_internet():
     with pytest.raises((ConnectionError, SocketBlockedError)):
         VortexTrack(storm="al062018", start_date="20180911", end_date=None)
 
-    breakpoint()
     track_1 = VortexTrack.from_file(input_directory / "fort.22", file_deck='b')
     track_1.to_file(output_directory / "vortex_1.22", overwrite=True)
 


### PR DESCRIPTION
`file_deck` and `advisory` properties should be found correctly when using the `from_file` command. 

This is affecting `EnsemblePerturbation` as it now requires to know the `file_deck` for doing the perturbations by forecast or hindcast. 