### PR TITLE
Feature/rmax fill nosmooth

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest ]
         python: [ '3.9', '3.10', '3.11' ]
     steps:
       - uses: actions/checkout@main

--- a/stormevents/nhc/const.py
+++ b/stormevents/nhc/const.py
@@ -8,6 +8,7 @@ class RMWFillMethod(Enum):
     none = None
     persistent = auto()
     regression_penny_2023 = auto()
+    regression_penny_2023_no_smoothing = auto()
 
 
 # Bias correction values for the Rmax forecast

--- a/stormevents/nhc/const.py
+++ b/stormevents/nhc/const.py
@@ -7,8 +7,8 @@ from pandas import DataFrame
 class RMWFillMethod(Enum):
     none = None
     persistent = auto()
-    regression_penny_2023 = auto()
     regression_penny_2023_with_smoothing = auto()
+    regression_penny_2023 = regression_penny_2023_with_smoothing
     regression_penny_2023_no_smoothing = auto()
 
 

--- a/stormevents/nhc/const.py
+++ b/stormevents/nhc/const.py
@@ -8,6 +8,7 @@ class RMWFillMethod(Enum):
     none = None
     persistent = auto()
     regression_penny_2023 = auto()
+    regression_penny_2023_with_smoothing = auto()
     regression_penny_2023_no_smoothing = auto()
 
 

--- a/stormevents/nhc/track.py
+++ b/stormevents/nhc/track.py
@@ -1379,6 +1379,7 @@ def correct_ofcl_based_on_carq_n_hollandb(
 
         elif (
             rmw_fill == RMWFillMethod.regression_penny_2023
+            or rmw_fill == RMWFillMethod.regression_penny_2023_with_smoothing
             or rmw_fill == RMWFillMethod.regression_penny_2023_no_smoothing
         ):
             # fill OFCL maximum wind radius based on regression method from
@@ -1436,7 +1437,10 @@ def correct_ofcl_based_on_carq_n_hollandb(
                     rmw_, 5.0, max(120.0, rmw0)
                 )
             # apply 24-HR moving mean to unique datetimes
-            if rmw_fill == RMWFillMethod.regression_penny_2023:
+            if (
+                rmw_fill == RMWFillMethod.regression_penny_2023
+                or rmw_fill == RMWFillMethod.regression_penny_2023_with_smoothing
+            ):
                 forecast = movingmean(forecast)
 
         # fill OFCL background pressure with the first entry from 0-hr CARQ background pressure (at sea level)

--- a/stormevents/nhc/track.py
+++ b/stormevents/nhc/track.py
@@ -1377,7 +1377,10 @@ def correct_ofcl_based_on_carq_n_hollandb(
                 "radius_of_maximum_winds"
             ]
 
-        elif rmw_fill == RMWFillMethod.regression_penny_2023:
+        elif (
+            rmw_fill == RMWFillMethod.regression_penny_2023
+            or rmw_fill == RMWFillMethod.regression_penny_2023_no_smoothing
+        ):
             # fill OFCL maximum wind radius based on regression method from
             # Penny et al. (2023). https://doi.org/10.1175/WAF-D-22-0209.1
             isotach_radii = forecast[

--- a/stormevents/nhc/track.py
+++ b/stormevents/nhc/track.py
@@ -1378,8 +1378,7 @@ def correct_ofcl_based_on_carq_n_hollandb(
             ]
 
         elif (
-            rmw_fill == RMWFillMethod.regression_penny_2023
-            or rmw_fill == RMWFillMethod.regression_penny_2023_with_smoothing
+            rmw_fill == RMWFillMethod.regression_penny_2023_with_smoothing
             or rmw_fill == RMWFillMethod.regression_penny_2023_no_smoothing
         ):
             # fill OFCL maximum wind radius based on regression method from
@@ -1437,10 +1436,7 @@ def correct_ofcl_based_on_carq_n_hollandb(
                     rmw_, 5.0, max(120.0, rmw0)
                 )
             # apply 24-HR moving mean to unique datetimes
-            if (
-                rmw_fill == RMWFillMethod.regression_penny_2023
-                or rmw_fill == RMWFillMethod.regression_penny_2023_with_smoothing
-            ):
+            if rmw_fill == RMWFillMethod.regression_penny_2023_with_smoothing:
                 forecast = movingmean(forecast)
 
         # fill OFCL background pressure with the first entry from 0-hr CARQ background pressure (at sea level)

--- a/stormevents/nhc/track.py
+++ b/stormevents/nhc/track.py
@@ -1405,7 +1405,7 @@ def correct_ofcl_based_on_carq_n_hollandb(
                 },
                 index=dt_12hr,
             )
-            rmw_rolling = df_temp.rolling(window="24.01 h", center=True, min_periods=1)[
+            rmw_rolling = df_temp.rolling(window="24h1min", center=True, min_periods=1)[
                 "radius_of_maximum_winds"
             ].mean()
             for valid_time, rmw in rmw_rolling.items():

--- a/tests/test_nhc.py
+++ b/tests/test_nhc.py
@@ -482,7 +482,24 @@ def test_rmw_fill_method_regression_penny_2023():
     rmw = data.loc[data.track_start_time == data.track_start_time.unique()[i_uq_row]][
         "radius_of_maximum_winds"
     ]
-    assert len(rmw.unique()) > 1
+    assert len(rmw.unique()) == 11
+
+
+def test_rmw_fill_method_regression_penny_2023_no_smoothing():
+    tr_florence2018 = VortexTrack.from_storm_name(
+        "Florence",
+        2018,
+        file_deck="a",
+        advisories=["OFCL"],
+        rmw_fill=RMWFillMethod.regression_penny_2023_no_smoothing,
+    )
+    assert tr_florence2018.rmw_fill == RMWFillMethod.regression_penny_2023_no_smoothing
+    data = tr_florence2018.data
+    i_uq_row = 40
+    rmw = data.loc[data.track_start_time == data.track_start_time.unique()[i_uq_row]][
+        "radius_of_maximum_winds"
+    ]
+    assert len(rmw.unique()) == 10
 
 
 def test_rmw_fill_method_setvalue_invalid():

--- a/tests/test_nhc.py
+++ b/tests/test_nhc.py
@@ -474,9 +474,11 @@ def test_rmw_fill_method_regression_penny_2023_with_smoothing():
         2018,
         file_deck="a",
         advisories=["OFCL"],
-        rmw_fill=RMWFillMethod.regression_penny_2023_with_smoothing,
+        rmw_fill=RMWFillMethod.regression_penny_2023,
     )
-    assert tr_florence2018.rmw_fill == RMWFillMethod.regression_penny_2023_with_smoothing
+    assert (
+        tr_florence2018.rmw_fill == RMWFillMethod.regression_penny_2023_with_smoothing
+    )
     data = tr_florence2018.data
     i_uq_row = 40
     rmw = data.loc[data.track_start_time == data.track_start_time.unique()[i_uq_row]][

--- a/tests/test_nhc.py
+++ b/tests/test_nhc.py
@@ -468,15 +468,15 @@ def test_rmw_fill_method_persistent():
     assert rmw.unique() == 10
 
 
-def test_rmw_fill_method_regression_penny_2023():
+def test_rmw_fill_method_regression_penny_2023_with_smoothing():
     tr_florence2018 = VortexTrack.from_storm_name(
         "Florence",
         2018,
         file_deck="a",
         advisories=["OFCL"],
-        rmw_fill=RMWFillMethod.regression_penny_2023,
+        rmw_fill=RMWFillMethod.regression_penny_2023_with_smoothing,
     )
-    assert tr_florence2018.rmw_fill == RMWFillMethod.regression_penny_2023
+    assert tr_florence2018.rmw_fill == RMWFillMethod.regression_penny_2023_with_smoothing
     data = tr_florence2018.data
     i_uq_row = 40
     rmw = data.loc[data.track_start_time == data.track_start_time.unique()[i_uq_row]][


### PR DESCRIPTION
Adding feature `regression_penny_2023_no_smoothing` for using Penny et al (2023) RMW filling without the 24-hr moving mean smoother function. 

Moving the smoothing to a function for added clarity to the code. 